### PR TITLE
feat(dataclasses): add __repr__ to all key dataclasses (#193)

### DIFF
--- a/src/agent_os/base_agent.py
+++ b/src/agent_os/base_agent.py
@@ -61,6 +61,9 @@ class AgentConfig:
     # FIXME: Add validation for agent_id format (should be alphanumeric with dashes)
     # TODO: Support loading config from YAML/JSON file
 
+    def __repr__(self) -> str:
+        return f"AgentConfig(agent_id={self.agent_id!r}, policies={self.policies!r})"
+
 
 @dataclass
 class AuditEntry:
@@ -73,7 +76,13 @@ class AuditEntry:
     decision: PolicyDecision
     result_success: Optional[bool] = None
     error: Optional[str] = None
-    
+
+    def __repr__(self) -> str:
+        return (
+            f"AuditEntry(agent_id={self.agent_id!r}, action={self.action!r}, "
+            f"decision={self.decision!r})"
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "timestamp": self.timestamp.isoformat(),

--- a/src/agent_os/integrations/base.py
+++ b/src/agent_os/integrations/base.py
@@ -32,6 +32,13 @@ class GovernancePolicy:
     max_concurrent: int = 10
     backpressure_threshold: int = 8  # Start slowing down at this level
 
+    def __repr__(self) -> str:
+        return (
+            f"GovernancePolicy(max_tokens={self.max_tokens!r}, "
+            f"max_tool_calls={self.max_tool_calls!r}, "
+            f"require_human_approval={self.require_human_approval!r})"
+        )
+
 
 @dataclass
 class ExecutionContext:
@@ -43,6 +50,9 @@ class ExecutionContext:
     call_count: int = 0
     tool_calls: list[dict] = field(default_factory=list)
     checkpoints: list[str] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        return f"ExecutionContext(agent_id={self.agent_id!r}, session_id={self.session_id!r})"
 
 
 # ── Abstract Tool Call Interceptor ────────────────────────────
@@ -56,6 +66,9 @@ class ToolCallRequest:
     agent_id: str = ""
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+    def __repr__(self) -> str:
+        return f"ToolCallRequest(tool_name={self.tool_name!r}, call_id={self.call_id!r})"
+
 
 @dataclass
 class ToolCallResult:
@@ -64,6 +77,9 @@ class ToolCallResult:
     reason: Optional[str] = None
     modified_arguments: Optional[Dict[str, Any]] = None  # For argument sanitization
     audit_entry: Optional[Dict[str, Any]] = None
+
+    def __repr__(self) -> str:
+        return f"ToolCallResult(allowed={self.allowed!r}, reason={self.reason!r})"
 
 
 class ToolCallInterceptor(Protocol):

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,139 @@
+"""
+Tests for __repr__ methods on dataclasses.
+
+Ensures readable, debug-friendly representations that show
+key fields only (no secrets or large data).
+
+Run with: python -m pytest tests/test_repr.py -v
+"""
+
+from datetime import datetime
+
+import pytest
+
+from agent_os.base_agent import AgentConfig, AuditEntry, PolicyDecision
+from agent_os.integrations.base import (
+    ExecutionContext,
+    GovernancePolicy,
+    ToolCallRequest,
+    ToolCallResult,
+)
+
+
+# =============================================================================
+# AgentConfig
+# =============================================================================
+
+
+class TestAgentConfigRepr:
+    def test_default(self):
+        cfg = AgentConfig(agent_id="agent-1")
+        assert repr(cfg) == "AgentConfig(agent_id='agent-1', policies=[])"
+
+    def test_with_policies(self):
+        cfg = AgentConfig(agent_id="agent-2", policies=["read_only", "no_pii"])
+        assert repr(cfg) == "AgentConfig(agent_id='agent-2', policies=['read_only', 'no_pii'])"
+
+    def test_metadata_omitted(self):
+        cfg = AgentConfig(agent_id="a", metadata={"secret": "key123"})
+        assert "secret" not in repr(cfg)
+        assert "key123" not in repr(cfg)
+
+
+# =============================================================================
+# AuditEntry
+# =============================================================================
+
+
+class TestAuditEntryRepr:
+    def test_repr(self):
+        entry = AuditEntry(
+            timestamp=datetime(2026, 1, 1),
+            agent_id="agent-1",
+            request_id="req-abc",
+            action="read_file",
+            params={"path": "/etc/passwd"},
+            decision=PolicyDecision.ALLOW,
+        )
+        r = repr(entry)
+        assert "AuditEntry(" in r
+        assert "agent_id='agent-1'" in r
+        assert "action='read_file'" in r
+        assert "decision=<PolicyDecision.ALLOW: 'allow'>" in r
+        # Sensitive params should not appear
+        assert "/etc/passwd" not in r
+
+
+# =============================================================================
+# GovernancePolicy
+# =============================================================================
+
+
+class TestGovernancePolicyRepr:
+    def test_default(self):
+        policy = GovernancePolicy()
+        r = repr(policy)
+        assert "GovernancePolicy(" in r
+        assert "max_tokens=4096" in r
+        assert "max_tool_calls=10" in r
+        assert "require_human_approval=False" in r
+
+    def test_custom_values(self):
+        policy = GovernancePolicy(max_tokens=2048, require_human_approval=True)
+        r = repr(policy)
+        assert "max_tokens=2048" in r
+        assert "require_human_approval=True" in r
+
+    def test_omits_internal_fields(self):
+        policy = GovernancePolicy(blocked_patterns=["password", "ssn"])
+        r = repr(policy)
+        assert "blocked_patterns" not in r
+
+
+# =============================================================================
+# ExecutionContext
+# =============================================================================
+
+
+class TestExecutionContextRepr:
+    def test_repr(self):
+        ctx = ExecutionContext(
+            agent_id="agent-1",
+            session_id="sess-abc",
+            policy=GovernancePolicy(),
+        )
+        r = repr(ctx)
+        assert "ExecutionContext(" in r
+        assert "agent_id='agent-1'" in r
+        assert "session_id='sess-abc'" in r
+
+
+# =============================================================================
+# ToolCallRequest
+# =============================================================================
+
+
+class TestToolCallRequestRepr:
+    def test_repr(self):
+        req = ToolCallRequest(tool_name="read_file", arguments={"path": "/secret"}, call_id="c-1")
+        r = repr(req)
+        assert "ToolCallRequest(" in r
+        assert "tool_name='read_file'" in r
+        assert "call_id='c-1'" in r
+        # Arguments should not leak
+        assert "/secret" not in r
+
+
+# =============================================================================
+# ToolCallResult
+# =============================================================================
+
+
+class TestToolCallResultRepr:
+    def test_allowed(self):
+        res = ToolCallResult(allowed=True)
+        assert repr(res) == "ToolCallResult(allowed=True, reason=None)"
+
+    def test_denied(self):
+        res = ToolCallResult(allowed=False, reason="blocked")
+        assert repr(res) == "ToolCallResult(allowed=False, reason='blocked')"


### PR DESCRIPTION
Fixes #193

Adds readable __repr__ methods to AgentConfig, AuditEntry, GovernancePolicy, ExecutionContext, ToolCallRequest, and ToolCallResult. Shows key fields only (no secrets). Includes 11 test cases.

*Created during the Octane AI-Powered Feature Development Workshop*