### PR TITLE
feat: make Redis key prefix configurable

### DIFF
--- a/src/agent_os/stateless.py
+++ b/src/agent_os/stateless.py
@@ -65,12 +65,11 @@ class MemoryBackend:
 class RedisBackend:
     """Redis state backend (for production)."""
     
-    def __init__(self, url: str = "redis://localhost:6379"):
+    def __init__(self, url: str = "redis://localhost:6379", key_prefix: str = "agent-os:"):
         self.url = url
         self._client = None
         # FIXME: Add connection timeout configuration
-        # HACK: Using hardcoded prefix - should be configurable
-        self._prefix = "agent-os:"
+        self._prefix = key_prefix
     
     async def _get_client(self):
         if self._client is None:

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -3,7 +3,9 @@ Test Stateless Kernel (MCP June 2026 compliant).
 """
 
 import pytest
+import json
 from typing import Dict, Any
+from unittest.mock import MagicMock, AsyncMock
 
 
 class TestStatelessKernel:
@@ -194,6 +196,61 @@ class TestMemoryBackend:
         result = await backend.get("nonexistent")
         
         assert result is None
+
+
+class TestRedisBackend:
+    """Test Redis state backend logic."""
+
+    def test_default_prefix(self):
+        """Test that the default prefix is set correctly."""
+        from agent_os.stateless import RedisBackend
+        
+        backend = RedisBackend()
+        assert backend._prefix == "agent-os:"
+
+    def test_custom_prefix(self):
+        """Test that a custom prefix is set correctly."""
+        from agent_os.stateless import RedisBackend
+        
+        custom_prefix = "my-custom-app:"
+        backend = RedisBackend(key_prefix=custom_prefix)
+        assert backend._prefix == custom_prefix
+
+    @pytest.mark.asyncio
+    async def test_operations_use_prefix(self):
+        """Test that get/set/delete operations actually use the prefix."""
+        from agent_os.stateless import RedisBackend
+        
+        # 1. Настраиваем backend и mock
+        prefix = "test-prefix:"
+        backend = RedisBackend(key_prefix=prefix)
+        
+        mock_client = AsyncMock()
+        
+        backend._client = mock_client
+        
+        test_key = "user-session-123"
+        test_value = {"status": "active"}
+        expected_redis_key = f"{prefix}{test_key}"
+        
+        await backend.set(test_key, test_value, ttl=60)
+        
+        mock_client.set.assert_called_with(
+            expected_redis_key, 
+            json.dumps(test_value), 
+            ex=60
+        )
+        
+        mock_client.get.return_value = json.dumps(test_value).encode('utf-8')
+        
+        result = await backend.get(test_key)
+        
+        mock_client.get.assert_called_with(expected_redis_key)
+        assert result == test_value
+        
+        await backend.delete(test_key)
+        
+        mock_client.delete.assert_called_with(expected_redis_key)
 
 
 class TestPolicyChecking:


### PR DESCRIPTION
## Description

This PR makes the Redis key prefix configurable in `RedisBackend`, resolving the issue where the prefix was hardcoded to `"agent-os:"`.

Key Changes:

- Updated `RedisBackend.__init__` to accept an optional key_prefix parameter.
- Maintained backward compatibility by setting the default value to `"agent-os:"`.
- Added comprehensive unit tests to verify both default and custom prefix behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Related Issues

Fixes #133 

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`pytest tests/ -v`)
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Testing

I verified the changes using pytest with mocked Redis calls to ensure correct key formation.

```bash
# Commands used to test
pytest tests/test_stateless.py -v
```

Test scenarios covered:

- Default Prefix: Verified that keys are still prefixed with agent-os: when no custom prefix is provided.
- Custom Prefix: Verified that providing a custom string (e.g., my-app:) correctly prefixes all keys during save and load operations.

## Screenshots (if applicable)

