### PR TITLE
feat: add performance profiling decorator for adapters

### DIFF
--- a/src/agent_os/integrations/profiling.py
+++ b/src/agent_os/integrations/profiling.py
@@ -1,0 +1,142 @@
+"""
+Performance profiling for governance checks and adapter operations.
+
+Provides a decorator and context manager for measuring execution time,
+call counts, and memory usage of adapter methods.
+"""
+
+import functools
+import time
+import tracemalloc
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+
+@dataclass
+class MethodStats:
+    """Statistics for a single profiled method."""
+    name: str
+    call_count: int = 0
+    total_time_ms: float = 0.0
+    min_time_ms: float = float("inf")
+    max_time_ms: float = 0.0
+    total_memory_delta: int = 0
+
+    @property
+    def avg_time_ms(self) -> float:
+        return self.total_time_ms / self.call_count if self.call_count else 0.0
+
+
+@dataclass
+class ProfilingReport:
+    """Aggregated profiling results."""
+    methods: dict[str, MethodStats] = field(default_factory=dict)
+
+    @property
+    def total_calls(self) -> int:
+        return sum(m.call_count for m in self.methods.values())
+
+    @property
+    def total_time_ms(self) -> float:
+        return sum(m.total_time_ms for m in self.methods.values())
+
+    def format_report(self) -> str:
+        """Return a human-readable table of profiling results."""
+        if not self.methods:
+            return "No profiling data collected."
+        header = f"{'Method':<30} {'Calls':>6} {'Total ms':>10} {'Avg ms':>10} {'Min ms':>10} {'Max ms':>10}"
+        sep = "-" * len(header)
+        lines = [header, sep]
+        for stats in sorted(self.methods.values(), key=lambda s: s.total_time_ms, reverse=True):
+            lines.append(
+                f"{stats.name:<30} {stats.call_count:>6} "
+                f"{stats.total_time_ms:>10.2f} {stats.avg_time_ms:>10.2f} "
+                f"{stats.min_time_ms:>10.2f} {stats.max_time_ms:>10.2f}"
+            )
+        lines.append(sep)
+        lines.append(f"{'TOTAL':<30} {self.total_calls:>6} {self.total_time_ms:>10.2f}")
+        return "\n".join(lines)
+
+
+# Global report used by the decorator
+_global_report = ProfilingReport()
+
+
+def get_report() -> ProfilingReport:
+    """Retrieve the global profiling report."""
+    return _global_report
+
+
+def reset_report() -> None:
+    """Reset the global profiling report."""
+    _global_report.methods.clear()
+
+
+def profile_governance(func: Optional[Callable] = None, *, track_memory: bool = False):
+    """Decorator that profiles execution time (and optionally memory) of a method.
+
+    Usage:
+        @profile_governance
+        def my_method(self, ...): ...
+
+        @profile_governance(track_memory=True)
+        def my_method(self, ...): ...
+    """
+    def decorator(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            key = fn.__name__
+            if key not in _global_report.methods:
+                _global_report.methods[key] = MethodStats(name=key)
+            stats = _global_report.methods[key]
+
+            mem_before = 0
+            if track_memory:
+                if not tracemalloc.is_tracing():
+                    tracemalloc.start()
+                _, mem_before = tracemalloc.get_traced_memory()
+
+            start = time.perf_counter()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                elapsed_ms = (time.perf_counter() - start) * 1000
+                stats.call_count += 1
+                stats.total_time_ms += elapsed_ms
+                stats.min_time_ms = min(stats.min_time_ms, elapsed_ms)
+                stats.max_time_ms = max(stats.max_time_ms, elapsed_ms)
+
+                if track_memory:
+                    _, mem_after = tracemalloc.get_traced_memory()
+                    stats.total_memory_delta += mem_after - mem_before
+
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+class ProfileGovernanceContext:
+    """Context manager for scoped profiling.
+
+    Usage:
+        with ProfileGovernanceContext() as report:
+            # run profiled code
+        print(report.format_report())
+    """
+
+    def __init__(self, track_memory: bool = False):
+        self.track_memory = track_memory
+        self.report = ProfilingReport()
+        self._previous_report: Optional[ProfilingReport] = None
+
+    def __enter__(self) -> ProfilingReport:
+        global _global_report
+        self._previous_report = _global_report
+        _global_report = self.report
+        return self.report
+
+    def __exit__(self, *exc: Any) -> None:
+        global _global_report
+        _global_report = self._previous_report  # type: ignore

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,132 @@
+"""Tests for governance profiling decorator and context manager."""
+
+import time
+
+import pytest
+
+from agent_os.integrations.profiling import (
+    MethodStats,
+    ProfileGovernanceContext,
+    ProfilingReport,
+    get_report,
+    profile_governance,
+    reset_report,
+)
+
+
+class TestMethodStats:
+    def test_avg_time_zero_calls(self):
+        s = MethodStats(name="test")
+        assert s.avg_time_ms == 0.0
+
+    def test_avg_time(self):
+        s = MethodStats(name="test", call_count=4, total_time_ms=100.0)
+        assert s.avg_time_ms == 25.0
+
+
+class TestProfilingReport:
+    def test_empty_report(self):
+        r = ProfilingReport()
+        assert r.total_calls == 0
+        assert r.total_time_ms == 0.0
+        assert "No profiling data" in r.format_report()
+
+    def test_format_report(self):
+        r = ProfilingReport(methods={
+            "a": MethodStats(name="a", call_count=2, total_time_ms=10.0, min_time_ms=4.0, max_time_ms=6.0),
+        })
+        text = r.format_report()
+        assert "a" in text
+        assert "TOTAL" in text
+        assert "2" in text
+
+
+class TestProfileGovernanceDecorator:
+    def setup_method(self):
+        reset_report()
+
+    def test_basic_timing(self):
+        @profile_governance
+        def slow():
+            time.sleep(0.05)
+
+        slow()
+        report = get_report()
+        stats = report.methods["slow"]
+        assert stats.call_count == 1
+        assert stats.total_time_ms >= 40  # at least 40ms
+
+    def test_multiple_calls(self):
+        @profile_governance
+        def fast():
+            pass
+
+        for _ in range(5):
+            fast()
+        stats = get_report().methods["fast"]
+        assert stats.call_count == 5
+
+    def test_return_value_preserved(self):
+        @profile_governance
+        def add(a, b):
+            return a + b
+
+        assert add(2, 3) == 5
+
+    def test_exception_still_recorded(self):
+        @profile_governance
+        def fails():
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            fails()
+        assert get_report().methods["fails"].call_count == 1
+
+    def test_min_max_tracking(self):
+        @profile_governance
+        def varied(t):
+            time.sleep(t)
+
+        varied(0.01)
+        varied(0.05)
+        stats = get_report().methods["varied"]
+        assert stats.min_time_ms < stats.max_time_ms
+
+    def test_decorator_with_track_memory(self):
+        @profile_governance(track_memory=True)
+        def allocate():
+            return [0] * 10000
+
+        allocate()
+        stats = get_report().methods["allocate"]
+        assert stats.call_count == 1
+        assert stats.total_memory_delta >= 0
+
+
+class TestProfileGovernanceContext:
+    def setup_method(self):
+        reset_report()
+
+    def test_scoped_report(self):
+        @profile_governance
+        def work():
+            time.sleep(0.01)
+
+        with ProfileGovernanceContext() as report:
+            work()
+
+        assert report.total_calls == 1
+        # Global report should be restored
+        assert get_report().total_calls == 0
+
+    def test_format_in_context(self):
+        @profile_governance
+        def task():
+            pass
+
+        with ProfileGovernanceContext() as report:
+            task()
+            task()
+
+        assert report.total_calls == 2
+        assert "TOTAL" in report.format_report()


### PR DESCRIPTION
Adds `@profile_governance` decorator and `ProfileGovernanceContext` for measuring execution time, call counts, and memory usage of adapter methods. Includes `ProfilingReport` with `format_report()` for human-readable output. 12 tests. 678 passed total.

Closes #221