### PR TITLE
feat: add RBAC and governance metrics (#220, #218)

### DIFF
--- a/src/agent_os/integrations/rbac.py
+++ b/src/agent_os/integrations/rbac.py
@@ -1,0 +1,143 @@
+"""
+Role-Based Access Control (RBAC) for Agent OS.
+
+Provides role assignment, policy lookup, and permission checking for agents.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+import yaml
+
+from agent_os.integrations.base import GovernancePolicy, PatternType
+
+
+class Role(Enum):
+    """Standard roles for agent access control."""
+    READER = "reader"
+    WRITER = "writer"
+    ADMIN = "admin"
+    AUDITOR = "auditor"
+
+
+# Action permissions per role
+_ROLE_PERMISSIONS: Dict[Role, set[str]] = {
+    Role.READER: {"read"},
+    Role.WRITER: {"read", "write", "search"},
+    Role.ADMIN: {"read", "write", "search", "admin", "delete", "audit"},
+    Role.AUDITOR: {"read", "search", "audit"},
+}
+
+# Default policy templates per role
+_DEFAULT_POLICIES: Dict[Role, GovernancePolicy] = {
+    Role.READER: GovernancePolicy(
+        max_tool_calls=0,
+        allowed_tools=[],
+        require_human_approval=True,
+    ),
+    Role.WRITER: GovernancePolicy(
+        max_tool_calls=5,
+        allowed_tools=["read", "write", "search"],
+        require_human_approval=False,
+    ),
+    Role.ADMIN: GovernancePolicy(
+        max_tool_calls=50,
+        allowed_tools=[],
+        max_tokens=16384,
+        require_human_approval=False,
+    ),
+    Role.AUDITOR: GovernancePolicy(
+        max_tool_calls=5,
+        allowed_tools=["read", "search", "audit"],
+        log_all_calls=True,
+        require_human_approval=False,
+    ),
+}
+
+DEFAULT_ROLE = Role.READER
+
+
+class RBACManager:
+    """Manages role-based access control for agents.
+
+    Assigns roles to agents, resolves governance policies per role,
+    and checks action permissions. Unknown agents receive the READER role.
+    """
+
+    def __init__(self) -> None:
+        self._roles: Dict[str, Role] = {}
+        self._custom_policies: Dict[Role, GovernancePolicy] = {}
+        self._custom_permissions: Dict[Role, set[str]] = {}
+
+    def assign_role(self, agent_id: str, role: Role) -> None:
+        """Assign a role to an agent."""
+        self._roles[agent_id] = role
+
+    def get_role(self, agent_id: str) -> Role:
+        """Return the role for an agent, defaulting to READER."""
+        return self._roles.get(agent_id, DEFAULT_ROLE)
+
+    def get_policy(self, agent_id: str) -> GovernancePolicy:
+        """Return the governance policy template for an agent's role."""
+        role = self.get_role(agent_id)
+        if role in self._custom_policies:
+            return self._custom_policies[role]
+        return _DEFAULT_POLICIES[role]
+
+    def has_permission(self, agent_id: str, action: str) -> bool:
+        """Check whether an agent is permitted to perform an action."""
+        role = self.get_role(agent_id)
+        perms = self._custom_permissions.get(role, _ROLE_PERMISSIONS.get(role, set()))
+        return action in perms
+
+    def remove_role(self, agent_id: str) -> None:
+        """Remove a role assignment, reverting the agent to the default role."""
+        self._roles.pop(agent_id, None)
+
+    # ── YAML serialisation ────────────────────────────────────
+
+    def to_yaml(self, path: str) -> None:
+        """Save current role assignments and custom definitions to a YAML file."""
+        data: Dict[str, object] = {
+            "assignments": {aid: role.value for aid, role in self._roles.items()},
+        }
+        if self._custom_policies:
+            data["custom_policies"] = {
+                role.value: yaml.safe_load(policy.to_yaml())
+                for role, policy in self._custom_policies.items()
+            }
+        if self._custom_permissions:
+            data["custom_permissions"] = {
+                role.value: sorted(perms)
+                for role, perms in self._custom_permissions.items()
+            }
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "RBACManager":
+        """Load an RBACManager from a YAML file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected a YAML mapping, got {type(data).__name__}")
+
+        mgr = cls()
+
+        # Role assignments
+        for agent_id, role_value in data.get("assignments", {}).items():
+            mgr.assign_role(agent_id, Role(role_value))
+
+        # Custom policies
+        for role_value, policy_dict in data.get("custom_policies", {}).items():
+            role = Role(role_value)
+            yaml_str = yaml.dump(policy_dict, default_flow_style=False)
+            mgr._custom_policies[role] = GovernancePolicy.from_yaml(yaml_str)
+
+        # Custom permissions
+        for role_value, perms_list in data.get("custom_permissions", {}).items():
+            role = Role(role_value)
+            mgr._custom_permissions[role] = set(perms_list)
+
+        return mgr

--- a/src/agent_os/metrics.py
+++ b/src/agent_os/metrics.py
@@ -1,0 +1,133 @@
+"""
+Governance Metrics Collector — Tracks policy enforcement statistics.
+
+Thread-safe singleton that records policy checks, violations, approvals,
+and blocked tool calls across all governance adapters.
+
+Example:
+    >>> from agent_os.metrics import metrics
+    >>>
+    >>> metrics.record_check("langchain", latency_ms=1.2, approved=True)
+    >>> metrics.record_violation("crewai")
+    >>> metrics.record_blocked("crewai")
+    >>> snap = metrics.snapshot()
+    >>> snap["total_checks"]  # 1
+    >>> snap["violations"]    # 1
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class GovernanceMetrics:
+    """Collects governance enforcement metrics across adapters.
+
+    All public methods are thread-safe via an internal lock.
+    """
+
+    total_checks: int = 0
+    violations: int = 0
+    approvals: int = 0
+    blocked: int = 0
+    avg_latency_ms: float = 0.0
+
+    _adapter_checks: Dict[str, int] = field(default_factory=dict)
+    _adapter_violations: Dict[str, int] = field(default_factory=dict)
+    _adapter_blocked: Dict[str, int] = field(default_factory=dict)
+    _total_latency_ms: float = field(default=0.0, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def record_check(self, adapter: str, latency_ms: float, approved: bool) -> None:
+        """Record a policy check result.
+
+        Args:
+            adapter: Adapter name (e.g. ``"langchain"``).
+            latency_ms: Time taken for the check in milliseconds.
+            approved: Whether the action was approved.
+        """
+        with self._lock:
+            self.total_checks += 1
+            self._total_latency_ms += latency_ms
+            self.avg_latency_ms = self._total_latency_ms / self.total_checks
+            self._adapter_checks[adapter] = self._adapter_checks.get(adapter, 0) + 1
+            if approved:
+                self.approvals += 1
+            else:
+                self.violations += 1
+                self._adapter_violations[adapter] = (
+                    self._adapter_violations.get(adapter, 0) + 1
+                )
+
+    def record_violation(self, adapter: str) -> None:
+        """Record a standalone policy violation.
+
+        Args:
+            adapter: Adapter name.
+        """
+        with self._lock:
+            self.violations += 1
+            self._adapter_violations[adapter] = (
+                self._adapter_violations.get(adapter, 0) + 1
+            )
+
+    def record_blocked(self, adapter: str) -> None:
+        """Record a blocked tool call.
+
+        Args:
+            adapter: Adapter name.
+        """
+        with self._lock:
+            self.blocked += 1
+            self._adapter_blocked[adapter] = (
+                self._adapter_blocked.get(adapter, 0) + 1
+            )
+
+    def snapshot(self) -> dict:
+        """Return a JSON-serializable snapshot of all metrics.
+
+        Returns:
+            Dictionary containing global and per-adapter metrics.
+        """
+        with self._lock:
+            return {
+                "total_checks": self.total_checks,
+                "violations": self.violations,
+                "approvals": self.approvals,
+                "blocked": self.blocked,
+                "avg_latency_ms": round(self.avg_latency_ms, 4),
+                "adapters": {
+                    adapter: {
+                        "checks": self._adapter_checks.get(adapter, 0),
+                        "violations": self._adapter_violations.get(adapter, 0),
+                        "blocked": self._adapter_blocked.get(adapter, 0),
+                    }
+                    for adapter in sorted(
+                        set(self._adapter_checks)
+                        | set(self._adapter_violations)
+                        | set(self._adapter_blocked)
+                    )
+                },
+            }
+
+    def reset(self) -> None:
+        """Reset all counters to zero (useful for test isolation)."""
+        with self._lock:
+            self.total_checks = 0
+            self.violations = 0
+            self.approvals = 0
+            self.blocked = 0
+            self.avg_latency_ms = 0.0
+            self._total_latency_ms = 0.0
+            self._adapter_checks.clear()
+            self._adapter_violations.clear()
+            self._adapter_blocked.clear()
+
+
+# Module-level singleton
+metrics = GovernanceMetrics()
+
+__all__ = ["GovernanceMetrics", "metrics"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,170 @@
+"""Tests for the governance metrics collector."""
+
+import threading
+
+import pytest
+
+from agent_os.metrics import GovernanceMetrics
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def m() -> GovernanceMetrics:
+    return GovernanceMetrics()
+
+
+# ── 1. Initial state ─────────────────────────────────────────
+
+
+def test_initial_state(m: GovernanceMetrics) -> None:
+    assert m.total_checks == 0
+    assert m.violations == 0
+    assert m.approvals == 0
+    assert m.blocked == 0
+    assert m.avg_latency_ms == 0.0
+
+
+# ── 2. record_check increments totals ────────────────────────
+
+
+def test_record_check_approved(m: GovernanceMetrics) -> None:
+    m.record_check("langchain", latency_ms=1.0, approved=True)
+    assert m.total_checks == 1
+    assert m.approvals == 1
+    assert m.violations == 0
+
+
+def test_record_check_denied(m: GovernanceMetrics) -> None:
+    m.record_check("crewai", latency_ms=2.0, approved=False)
+    assert m.total_checks == 1
+    assert m.approvals == 0
+    assert m.violations == 1
+
+
+# ── 3. record_violation increments violations ────────────────
+
+
+def test_record_violation(m: GovernanceMetrics) -> None:
+    m.record_violation("langchain")
+    assert m.violations == 1
+    m.record_violation("langchain")
+    assert m.violations == 2
+
+
+# ── 4. record_blocked increments blocked ─────────────────────
+
+
+def test_record_blocked(m: GovernanceMetrics) -> None:
+    m.record_blocked("crewai")
+    assert m.blocked == 1
+    m.record_blocked("crewai")
+    assert m.blocked == 2
+
+
+# ── 5. Average latency calculation ───────────────────────────
+
+
+def test_avg_latency(m: GovernanceMetrics) -> None:
+    m.record_check("a", latency_ms=2.0, approved=True)
+    m.record_check("a", latency_ms=4.0, approved=True)
+    m.record_check("a", latency_ms=6.0, approved=True)
+    assert m.avg_latency_ms == pytest.approx(4.0)
+
+
+# ── 6. Per-adapter tracking ──────────────────────────────────
+
+
+def test_per_adapter_tracking(m: GovernanceMetrics) -> None:
+    m.record_check("langchain", latency_ms=1.0, approved=True)
+    m.record_check("crewai", latency_ms=2.0, approved=False)
+    m.record_violation("crewai")
+    m.record_blocked("langchain")
+
+    snap = m.snapshot()
+    assert snap["adapters"]["langchain"]["checks"] == 1
+    assert snap["adapters"]["langchain"]["violations"] == 0
+    assert snap["adapters"]["langchain"]["blocked"] == 1
+    assert snap["adapters"]["crewai"]["checks"] == 1
+    assert snap["adapters"]["crewai"]["violations"] == 2
+    assert snap["adapters"]["crewai"]["blocked"] == 0
+
+
+# ── 7. snapshot returns correct dict ─────────────────────────
+
+
+def test_snapshot(m: GovernanceMetrics) -> None:
+    m.record_check("langchain", latency_ms=3.0, approved=True)
+    m.record_check("langchain", latency_ms=5.0, approved=False)
+    m.record_blocked("langchain")
+
+    snap = m.snapshot()
+    assert snap["total_checks"] == 2
+    assert snap["approvals"] == 1
+    assert snap["violations"] == 1
+    assert snap["blocked"] == 1
+    assert snap["avg_latency_ms"] == pytest.approx(4.0)
+    assert "langchain" in snap["adapters"]
+
+
+# ── 8. reset clears all counters ─────────────────────────────
+
+
+def test_reset(m: GovernanceMetrics) -> None:
+    m.record_check("langchain", latency_ms=5.0, approved=True)
+    m.record_violation("crewai")
+    m.record_blocked("crewai")
+    m.reset()
+
+    assert m.total_checks == 0
+    assert m.violations == 0
+    assert m.approvals == 0
+    assert m.blocked == 0
+    assert m.avg_latency_ms == 0.0
+    assert m.snapshot()["adapters"] == {}
+
+
+# ── 9. Thread safety ─────────────────────────────────────────
+
+
+def test_thread_safety(m: GovernanceMetrics) -> None:
+    n = 1000
+    errors: list = []
+
+    def worker() -> None:
+        try:
+            for _ in range(n):
+                m.record_check("adapter", latency_ms=1.0, approved=True)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert m.total_checks == 4 * n
+    assert m.approvals == 4 * n
+
+
+# ── 10. Multiple adapters tracked independently ──────────────
+
+
+def test_multiple_adapters_independent(m: GovernanceMetrics) -> None:
+    m.record_check("langchain", latency_ms=1.0, approved=True)
+    m.record_check("langchain", latency_ms=1.0, approved=True)
+    m.record_check("crewai", latency_ms=2.0, approved=False)
+    m.record_violation("autogen")
+    m.record_blocked("crewai")
+
+    snap = m.snapshot()
+    assert snap["adapters"]["langchain"] == {"checks": 2, "violations": 0, "blocked": 0}
+    assert snap["adapters"]["crewai"] == {"checks": 1, "violations": 1, "blocked": 1}
+    assert snap["adapters"]["autogen"] == {"checks": 0, "violations": 1, "blocked": 0}
+    assert m.total_checks == 3
+    assert m.approvals == 2
+    assert m.violations == 2
+    assert m.blocked == 1

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,211 @@
+"""Tests for the RBAC module."""
+
+import os
+import tempfile
+
+import pytest
+
+from agent_os.integrations.base import GovernancePolicy
+from agent_os.integrations.rbac import DEFAULT_ROLE, Role, RBACManager
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mgr() -> RBACManager:
+    return RBACManager()
+
+
+# ── 1. Role assignment and retrieval ─────────────────────────
+
+
+def test_assign_and_get_role(mgr: RBACManager) -> None:
+    mgr.assign_role("agent-1", Role.WRITER)
+    assert mgr.get_role("agent-1") is Role.WRITER
+
+
+# ── 2. Policy lookup per role ─────────────────────────────────
+
+
+def test_reader_policy(mgr: RBACManager) -> None:
+    mgr.assign_role("r", Role.READER)
+    p = mgr.get_policy("r")
+    assert p.max_tool_calls == 0
+    assert p.allowed_tools == []
+    assert p.require_human_approval is True
+
+
+def test_writer_policy(mgr: RBACManager) -> None:
+    mgr.assign_role("w", Role.WRITER)
+    p = mgr.get_policy("w")
+    assert p.max_tool_calls == 5
+    assert p.allowed_tools == ["read", "write", "search"]
+    assert p.require_human_approval is False
+
+
+def test_admin_policy(mgr: RBACManager) -> None:
+    mgr.assign_role("a", Role.ADMIN)
+    p = mgr.get_policy("a")
+    assert p.max_tool_calls == 50
+    assert p.allowed_tools == []
+    assert p.max_tokens == 16384
+    assert p.require_human_approval is False
+
+
+def test_auditor_policy(mgr: RBACManager) -> None:
+    mgr.assign_role("au", Role.AUDITOR)
+    p = mgr.get_policy("au")
+    assert p.max_tool_calls == 5
+    assert p.allowed_tools == ["read", "search", "audit"]
+    assert p.log_all_calls is True
+    assert p.require_human_approval is False
+
+
+# ── 3. Permission checking ───────────────────────────────────
+
+
+def test_reader_permissions(mgr: RBACManager) -> None:
+    mgr.assign_role("r", Role.READER)
+    assert mgr.has_permission("r", "read") is True
+    assert mgr.has_permission("r", "write") is False
+    assert mgr.has_permission("r", "admin") is False
+
+
+def test_writer_permissions(mgr: RBACManager) -> None:
+    mgr.assign_role("w", Role.WRITER)
+    assert mgr.has_permission("w", "read") is True
+    assert mgr.has_permission("w", "write") is True
+    assert mgr.has_permission("w", "search") is True
+    assert mgr.has_permission("w", "admin") is False
+
+
+def test_admin_permissions(mgr: RBACManager) -> None:
+    mgr.assign_role("a", Role.ADMIN)
+    for action in ("read", "write", "search", "admin", "delete", "audit"):
+        assert mgr.has_permission("a", action) is True
+
+
+def test_auditor_permissions(mgr: RBACManager) -> None:
+    mgr.assign_role("au", Role.AUDITOR)
+    assert mgr.has_permission("au", "read") is True
+    assert mgr.has_permission("au", "search") is True
+    assert mgr.has_permission("au", "audit") is True
+    assert mgr.has_permission("au", "write") is False
+
+
+# ── 4. Unknown agent gets default READER role ────────────────
+
+
+def test_unknown_agent_default_role(mgr: RBACManager) -> None:
+    assert mgr.get_role("unknown-agent") is DEFAULT_ROLE
+    assert mgr.get_role("unknown-agent") is Role.READER
+
+
+def test_unknown_agent_default_policy(mgr: RBACManager) -> None:
+    p = mgr.get_policy("unknown-agent")
+    assert p.max_tool_calls == 0
+    assert p.require_human_approval is True
+
+
+def test_unknown_agent_permissions(mgr: RBACManager) -> None:
+    assert mgr.has_permission("unknown-agent", "read") is True
+    assert mgr.has_permission("unknown-agent", "write") is False
+
+
+# ── 5. Role removal ──────────────────────────────────────────
+
+
+def test_remove_role(mgr: RBACManager) -> None:
+    mgr.assign_role("agent-1", Role.ADMIN)
+    assert mgr.get_role("agent-1") is Role.ADMIN
+    mgr.remove_role("agent-1")
+    assert mgr.get_role("agent-1") is Role.READER
+
+
+def test_remove_nonexistent_role(mgr: RBACManager) -> None:
+    mgr.remove_role("no-such-agent")  # should not raise
+
+
+# ── 6. Custom role definitions via YAML ──────────────────────
+
+
+def test_yaml_roundtrip(mgr: RBACManager) -> None:
+    mgr.assign_role("a1", Role.WRITER)
+    mgr.assign_role("a2", Role.ADMIN)
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+        path = f.name
+    try:
+        mgr.to_yaml(path)
+        loaded = RBACManager.from_yaml(path)
+        assert loaded.get_role("a1") is Role.WRITER
+        assert loaded.get_role("a2") is Role.ADMIN
+    finally:
+        os.unlink(path)
+
+
+def test_yaml_with_custom_policy(mgr: RBACManager) -> None:
+    custom = GovernancePolicy(max_tool_calls=99, allowed_tools=["custom_tool"])
+    mgr._custom_policies[Role.WRITER] = custom
+    mgr.assign_role("agent-x", Role.WRITER)
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+        path = f.name
+    try:
+        mgr.to_yaml(path)
+        loaded = RBACManager.from_yaml(path)
+        p = loaded.get_policy("agent-x")
+        assert p.max_tool_calls == 99
+        assert p.allowed_tools == ["custom_tool"]
+    finally:
+        os.unlink(path)
+
+
+def test_yaml_with_custom_permissions(mgr: RBACManager) -> None:
+    mgr._custom_permissions[Role.READER] = {"read", "custom_action"}
+    mgr.assign_role("agent-y", Role.READER)
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+        path = f.name
+    try:
+        mgr.to_yaml(path)
+        loaded = RBACManager.from_yaml(path)
+        assert loaded.has_permission("agent-y", "custom_action") is True
+        assert loaded.has_permission("agent-y", "read") is True
+    finally:
+        os.unlink(path)
+
+
+# ── 7. Multiple agents with different roles ──────────────────
+
+
+def test_multiple_agents(mgr: RBACManager) -> None:
+    mgr.assign_role("reader-bot", Role.READER)
+    mgr.assign_role("writer-bot", Role.WRITER)
+    mgr.assign_role("admin-bot", Role.ADMIN)
+    mgr.assign_role("auditor-bot", Role.AUDITOR)
+
+    assert mgr.get_role("reader-bot") is Role.READER
+    assert mgr.get_role("writer-bot") is Role.WRITER
+    assert mgr.get_role("admin-bot") is Role.ADMIN
+    assert mgr.get_role("auditor-bot") is Role.AUDITOR
+
+    assert mgr.has_permission("writer-bot", "write") is True
+    assert mgr.has_permission("reader-bot", "write") is False
+    assert mgr.has_permission("admin-bot", "delete") is True
+    assert mgr.has_permission("auditor-bot", "audit") is True
+
+
+# ── 8. Re-assigning a role updates correctly ─────────────────
+
+
+def test_reassign_role(mgr: RBACManager) -> None:
+    mgr.assign_role("agent-1", Role.READER)
+    assert mgr.get_role("agent-1") is Role.READER
+    assert mgr.has_permission("agent-1", "write") is False
+
+    mgr.assign_role("agent-1", Role.ADMIN)
+    assert mgr.get_role("agent-1") is Role.ADMIN
+    assert mgr.has_permission("agent-1", "write") is True
+    assert mgr.get_policy("agent-1").max_tokens == 16384


### PR DESCRIPTION
## Changes

### RBAC Module (#220)
- New \src/agent_os/integrations/rbac.py\ with \Role\ enum and \RBACManager\
- 4 built-in roles: READER, WRITER, ADMIN, AUDITOR
- Default policy templates per role (READER = most restrictive, ADMIN = full access)
- \has_permission()\ for action-level access control
- YAML import/export for custom role definitions
- 19 tests in \	ests/test_rbac.py\

### Governance Metrics Collector (#218)
- New \src/agent_os/metrics.py\ with \GovernanceMetrics\
- Tracks: total_checks, violations, approvals, blocked, avg_latency_ms
- Per-adapter metrics (e.g., langchain_checks, crewai_violations)
- Thread-safe with \	hreading.Lock\
- \snapshot()\ for JSON export, \eset()\ for test isolation
- 11 tests in \	ests/test_metrics.py\

### Test Results
- 727 passed, 0 failed (up from 697)
- 30 new tests across both modules

Closes #220, closes #218