### PR TITLE
feat: add AGENTS.md generator (#198)

### DIFF
--- a/src/agent_os/agents_compat.py
+++ b/src/agent_os/agents_compat.py
@@ -3,6 +3,9 @@ AGENTS.md Compatibility for Agent OS.
 
 Parses OpenAI/Anthropic standard .agents/ directory structure
 and maps to Agent OS kernel policies.
+
+Also provides generation utilities for producing AGENTS.md files
+from AgentMdConfig dataclasses (GitHub Copilot / Cursor / Codex format).
 """
 
 from dataclasses import dataclass, field
@@ -10,6 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 import re
 import yaml
+
+from agent_os.integrations.base import GovernancePolicy, PatternType
 
 
 @dataclass
@@ -284,3 +289,199 @@ def discover_agents(root_dir: str = ".") -> List[AgentConfig]:
                 pass
     
     return configs
+
+
+# ── AGENTS.md Generator ──────────────────────────────────────────────────────
+
+
+_AGENTS_MD_VERSION = "1.0"
+
+
+@dataclass
+class AgentMdConfig:
+    """Configuration for generating an AGENTS.md file.
+
+    Maps Agent OS concepts (governance policy, RBAC role, tools) into the
+    standard AGENTS.md format consumed by GitHub Copilot, Cursor, Codex, etc.
+    """
+
+    name: str
+    description: str = ""
+    tools: list[str] = field(default_factory=list)
+    policy: Optional[GovernancePolicy] = None
+    role: Optional[str] = None
+    build_commands: list[str] = field(default_factory=list)
+    test_commands: list[str] = field(default_factory=list)
+    lint_commands: list[str] = field(default_factory=list)
+    boundaries: list[str] = field(default_factory=list)
+    code_style: Dict[str, str] = field(default_factory=dict)
+
+
+def generate_agents_md(config: AgentMdConfig) -> str:
+    """Generate a valid AGENTS.md string from *config*.
+
+    The output includes YAML frontmatter followed by Markdown sections for
+    project overview, build & test commands, code style, governance,
+    boundaries, and commit style.
+    """
+
+    parts: list[str] = []
+
+    # ── YAML frontmatter ─────────────────────────────────────────────────
+    fm: Dict[str, Any] = {
+        "name": config.name,
+        "version": _AGENTS_MD_VERSION,
+    }
+    if config.description:
+        fm["description"] = config.description
+    if config.tools:
+        fm["tools"] = config.tools
+    if config.role:
+        fm["role"] = config.role
+
+    parts.append("---")
+    parts.append(yaml.dump(fm, default_flow_style=False, sort_keys=False).rstrip())
+    parts.append("---")
+    parts.append("")
+
+    # ── Title ────────────────────────────────────────────────────────────
+    parts.append(f"# {config.name} — Coding Agent Instructions")
+    parts.append("")
+
+    # ── Project Overview ─────────────────────────────────────────────────
+    if config.description:
+        parts.append("## Project Overview")
+        parts.append("")
+        parts.append(config.description)
+        parts.append("")
+
+    # ── Build & Test Commands ────────────────────────────────────────────
+    has_commands = config.build_commands or config.test_commands or config.lint_commands
+    if has_commands:
+        parts.append("## Build & Test Commands")
+        parts.append("")
+        parts.append("```bash")
+        for cmd in config.build_commands:
+            parts.append(cmd)
+        for cmd in config.test_commands:
+            parts.append(cmd)
+        for cmd in config.lint_commands:
+            parts.append(cmd)
+        parts.append("```")
+        parts.append("")
+
+    # ── Code Style ───────────────────────────────────────────────────────
+    if config.code_style:
+        parts.append("## Code Style")
+        parts.append("")
+        for key, value in config.code_style.items():
+            parts.append(f"- **{key}:** {value}")
+        parts.append("")
+
+    # ── Governance ───────────────────────────────────────────────────────
+    if config.policy is not None:
+        parts.append("## Governance")
+        parts.append("")
+        parts.append("```yaml")
+        parts.append(config.policy.to_yaml().rstrip())
+        parts.append("```")
+        parts.append("")
+
+    # ── Boundaries ───────────────────────────────────────────────────────
+    if config.boundaries:
+        parts.append("## Boundaries")
+        parts.append("")
+        for boundary in config.boundaries:
+            parts.append(f"- {boundary}")
+        parts.append("")
+
+    # ── Commit Style ─────────────────────────────────────────────────────
+    parts.append("## Commit Style")
+    parts.append("")
+    parts.append(
+        "Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`"
+    )
+    parts.append("")
+
+    return "\n".join(parts)
+
+
+def save_agents_md(config: AgentMdConfig, path: str) -> None:
+    """Write the generated AGENTS.md to *path*."""
+
+    content = generate_agents_md(config)
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def load_agents_md(path: str) -> AgentMdConfig:
+    """Parse an AGENTS.md file back into an *AgentMdConfig*.
+
+    Extracts YAML frontmatter for metadata and scans Markdown sections for
+    build/test/lint commands, code style, governance policy, and boundaries.
+    """
+
+    text = Path(path).read_text(encoding="utf-8")
+
+    # ── Parse YAML frontmatter ───────────────────────────────────────────
+    fm: Dict[str, Any] = {}
+    body = text
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            fm = yaml.safe_load(text[3:end]) or {}
+            body = text[end + 3:].strip()
+
+    config = AgentMdConfig(
+        name=fm.get("name", "agent"),
+        description=fm.get("description", ""),
+        tools=fm.get("tools", []),
+        role=fm.get("role"),
+    )
+
+    # ── Section regex (## Heading) ───────────────────────────────────────
+    section_re = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+    sections: Dict[str, str] = {}
+    matches = list(section_re.finditer(body))
+    for i, m in enumerate(matches):
+        heading = m.group(1).strip()
+        start = m.end()
+        end_pos = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[heading] = body[start:end_pos].strip()
+
+    # ── Build & Test Commands ────────────────────────────────────────────
+    bt_section = sections.get("Build & Test Commands", "")
+    code_block = re.search(r"```(?:bash)?\s*\n(.*?)```", bt_section, re.DOTALL)
+    if code_block:
+        lines = [ln for ln in code_block.group(1).strip().splitlines() if ln.strip()]
+        # Simple heuristic: commands containing "test" → test, "lint"/"check"/"format" → lint, rest → build
+        for ln in lines:
+            low = ln.lower()
+            if "test" in low or "pytest" in low:
+                config.test_commands.append(ln)
+            elif any(kw in low for kw in ("lint", "check", "format", "ruff", "mypy")):
+                config.lint_commands.append(ln)
+            else:
+                config.build_commands.append(ln)
+
+    # ── Code Style ───────────────────────────────────────────────────────
+    cs_section = sections.get("Code Style", "")
+    for line in cs_section.splitlines():
+        # Matches both `**key:** value` and `**key**: value`
+        m = re.match(r"^-\s+\*\*(.+?):?\*\*:?\s*(.+)$", line.strip())
+        if m:
+            config.code_style[m.group(1).rstrip(":")] = m.group(2)
+
+    # ── Governance ───────────────────────────────────────────────────────
+    gov_section = sections.get("Governance", "")
+    gov_block = re.search(r"```(?:yaml)?\s*\n(.*?)```", gov_section, re.DOTALL)
+    if gov_block:
+        config.policy = GovernancePolicy.from_yaml(gov_block.group(1))
+
+    # ── Boundaries ───────────────────────────────────────────────────────
+    bd_section = sections.get("Boundaries", "")
+    for line in bd_section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            config.boundaries.append(stripped[2:])
+
+    return config


### PR DESCRIPTION
## Changes

- New \src/agent_os/agents_compat.py\ with \AgentMdConfig\ dataclass
- \generate_agents_md(config)\ — produces valid AGENTS.md with YAML frontmatter and governance section
- \save_agents_md(config, path)\ — writes AGENTS.md to file
- \load_agents_md(path)\ — parses AGENTS.md back into config (roundtrip-safe)
- GovernancePolicy renders as YAML in the Governance section
- 7 tests in \	ests/test_agents_compat.py\ (+ 15 existing = 22 total)

Closes #198