### PR TITLE
fix: add pyyaml as a required dependency for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 # Core dependencies (minimal - just what's needed for kernel)
 dependencies = [
     "pydantic>=2.0.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description
This pull request introduces a minor update to the project's dependencies by adding a new requirement.
## Fix: Add `pyyaml` to core dependencies

Fixes #288

### Summary

`pyyaml` was missing from the core `dependencies` in `pyproject.toml`, causing a `ModuleNotFoundError: No module named 'yaml'` on every fresh install of `agent-os-kernel`. This broke the package at import time before any user code could run.

### Root Cause

Both `agents_compat.py` (line 15) and `rbac.py` (line 11) use top-level `import yaml`. Since `__init__.py` imports these modules unconditionally, `pyyaml` is a hard runtime requirement — but was only present in `dev` and `nexus` optional extras, not in core `dependencies`.

### Changes

**`pyproject.toml`**
```toml
# Before
dependencies = [
    "pydantic>=2.0.0",
]

# After
dependencies = [
    "pydantic>=2.0.0",
    "pyyaml>=6.0.0",
]
```


## Type of Change

<!-- Mark with an `x` all that apply -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Related Issues

<!-- Link any related issues here using #issue_number -->

Fixes #

## Checklist

<!-- Mark with an `x` all that apply -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`pytest tests/ -v`)
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings
